### PR TITLE
 Fix HeaderToField for Maps to be similar to Struct behaviour.

### DIFF
--- a/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/BytesToString.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/BytesToString.java
@@ -55,7 +55,9 @@ public abstract class BytesToString<R extends ConnectRecord<R>> extends BaseTran
   @Override
   protected SchemaAndValue processBytes(R record, Schema inputSchema, byte[] input) {
     final Schema outputSchema = inputSchema.isOptional() ? Schema.OPTIONAL_STRING_SCHEMA : Schema.STRING_SCHEMA;
-    final String output = new String(input, this.config.charset);
+    final String output =  input != null
+            ?  new String(input, this.config.charset)
+            : (String) inputSchema.defaultValue();
     return new SchemaAndValue(outputSchema, output);
   }
 
@@ -91,7 +93,12 @@ public abstract class BytesToString<R extends ConnectRecord<R>> extends BaseTran
     for (Field field : schema.fields()) {
       if (this.config.fields.contains(field.name())) {
         byte[] buffer = input.getBytes(field.name());
-        struct.put(field.name(), new String(buffer, this.config.charset));
+        struct.put(
+                field.name(),
+                buffer != null
+                  ?  new String(buffer, this.config.charset)
+                : field.schema().defaultValue()
+        );
       } else {
         struct.put(field.name(), input.get(field.name()));
       }

--- a/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/ChangeCase.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/ChangeCase.java
@@ -65,6 +65,10 @@ public abstract class ChangeCase<R extends ConnectRecord<R>> extends BaseTransfo
 
   private Struct convertStruct(Schema inputSchema, Schema outputSchema, Struct input) {
     final Struct struct = new Struct(outputSchema);
+
+    if (input == null)
+      return struct;
+
     for (Field inputField : inputSchema.fields()) {
       final int index = inputField.index();
       final Field outputField = outputSchema.fields().get(index);

--- a/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractNestedField.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractNestedField.java
@@ -71,7 +71,7 @@ public abstract class ExtractNestedField<R extends ConnectRecord<R>> extends Bas
       for (Field inputField : inputSchema.fields()) {
         builder.field(inputField.name(), inputField.schema());
       }
-      builder.field(this.config.innerFieldName, innerField.schema());
+      builder.field(this.config.outputFieldName, innerField.schema());
       return builder.build();
     });
     final Struct outputStruct = new Struct(outputSchema);
@@ -80,7 +80,7 @@ public abstract class ExtractNestedField<R extends ConnectRecord<R>> extends Bas
       outputStruct.put(inputField.name(), value);
     }
     final Object innerFieldValue = innerStruct.get(this.config.innerFieldName);
-    outputStruct.put(this.config.innerFieldName, innerFieldValue);
+    outputStruct.put(this.config.outputFieldName, innerFieldValue);
 
     return new SchemaAndValue(outputSchema, outputStruct);
 

--- a/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/HeaderToField.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/HeaderToField.java
@@ -117,7 +117,7 @@ public class HeaderToField<R extends ConnectRecord<R>> extends BaseKeyValueTrans
       this.config.mappings.forEach(mapping -> {
         for (Header header: record.headers()) {
           if (header.key().equals(mapping.header)) {
-            headers.put(header.key(), header.value());
+            headers.put(mapping.field, header.value());
             break;
           }
         }

--- a/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/HeaderToField.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/HeaderToField.java
@@ -124,7 +124,7 @@ public class HeaderToField<R extends ConnectRecord<R>> extends BaseKeyValueTrans
       });
     }
 
-    input.put("_headers", headers);
+    input.putAll(headers);
     return new SchemaAndValue(null, input);
   }
 

--- a/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/BytesToStringTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/BytesToStringTest.java
@@ -68,6 +68,52 @@ public abstract class BytesToStringTest extends TransformationTest {
     assertSchema(Schema.STRING_SCHEMA, outputRecord.valueSchema());
   }
 
+  @Test
+  public void nullBytes() throws UnsupportedEncodingException {
+    this.transformation.configure(
+            ImmutableMap.of()
+    );
+    final String expected =  null;
+    final SinkRecord inputRecord = new SinkRecord(
+            "topic",
+            1,
+            null,
+            null,
+            Schema.OPTIONAL_BYTES_SCHEMA,
+            expected,
+            1L
+    );
+
+    SinkRecord outputRecord = this.transformation.apply(inputRecord);
+    assertEquals(expected, outputRecord.value());
+    assertSchema(Schema.OPTIONAL_STRING_SCHEMA, outputRecord.valueSchema());
+  }
+
+  @Test
+  public void nullStructFieldBytes() throws UnsupportedEncodingException {
+    this.transformation.configure(
+            ImmutableMap.of(BytesToStringConfig.FIELD_CONFIG, "bytes")
+    );
+    final String expected =  null;
+    Schema schema = SchemaBuilder.struct()
+            .field("bytes", Schema.OPTIONAL_BYTES_SCHEMA)
+            .build();
+    Struct struct = new Struct(schema)
+            .put("bytes", expected);
+
+    final SinkRecord inputRecord = new SinkRecord(
+            "topic",
+            1,
+            null,
+            null,
+            schema,
+            struct,
+            1L
+    );
+
+    SinkRecord outputRecord = this.transformation.apply(inputRecord);
+  }
+
   public static class ValueTest<R extends ConnectRecord<R>> extends BytesToStringTest {
     protected ValueTest() {
       super(false);


### PR DESCRIPTION
Fix HeaderToFieldTest.

Let HeaderToField add new fields to the root of the Map,
similar to how it works for Structs.
Fix the test: Maps don't have a schema, you only needed
to test the value.